### PR TITLE
[Fix_2]: Valor default para atividade finalizada

### DIFF
--- a/db/migrate/20240606232200_create_tasks.rb
+++ b/db/migrate/20240606232200_create_tasks.rb
@@ -3,7 +3,7 @@ class CreateTasks < ActiveRecord::Migration[7.1]
     create_table :tasks do |t|
       t.string :name, limit: 50
       t.string :description, limit: 140
-      t.boolean :completed, null: false
+      t.boolean :completed, null: false, default: false
       t.date :due_date
       t.integer :priority, null: false, default: 0
       t.references :member, null: false, foreign_key: true


### PR DESCRIPTION
Resumo das Alterações:
Valor inicial para a tarefa se foi finalizada ou não

Motivação:
Quando a tarefa for criada o ideal é que ela inicie sendo não finalizada

Mudanças Realizadas:

Alteração na migration das tasks difinindo o valor padrão para o campo finalizada como false.

